### PR TITLE
Add alternating section backgrounds

### DIFF
--- a/src/components/sections/Contact/Contact.module.scss
+++ b/src/components/sections/Contact/Contact.module.scss
@@ -1,5 +1,5 @@
 .container {
-  padding-top: 10px;
+  width: 100%;
 }
 
 .title {

--- a/src/components/sections/Experience/Experience.module.scss
+++ b/src/components/sections/Experience/Experience.module.scss
@@ -1,5 +1,5 @@
 .container {
-  padding-top: 10px;
+  width: 100%;
 }
 
 .expsContainer {

--- a/src/components/sections/Solutions/Solutions.module.scss
+++ b/src/components/sections/Solutions/Solutions.module.scss
@@ -1,5 +1,5 @@
 .container {
-  padding-top: 10px;
+  width: 100%;
 }
 
 .title {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,7 +13,6 @@ export default () => {
     <Layout>
       <About />
       <Experience />
-      <div id="spacer" style={{ paddingTop: "500px" }}></div>
       <Solutions />
       <Contact />
     </Layout>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,6 +1,7 @@
 :root {
   --dark-navy-blue: #091a2a;
   --darker-navy-blue: #091621;
+  --section-alt-blue: #0c2236;
   --light-blue: #38bdf8;
   --lighter-blue: #67c9f4;
   --titanium-blue: #003459;
@@ -19,6 +20,22 @@ body {
   padding: 0px;
   font-family: var(--font-inter);
   background-color: var(--dark-navy-blue);
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+}
+
+main section {
+  box-sizing: border-box;
+  min-height: calc(100vh - 100px);
+  padding: 80px 100px;
+  background-color: var(--dark-navy-blue);
+}
+
+main section:nth-of-type(even) {
+  background-color: var(--section-alt-blue);
 }
 
 a {


### PR DESCRIPTION
## Summary
- add alternating background colors and shared spacing to site sections
- remove the manual spacer so sections flow directly into one another
- normalize section container styling for consistent layout and padding

## Testing
- yarn typecheck *(fails: dependencies could not be installed because of a registry 403 error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69436145f2a8832e891e57f1f918d248)