### PR TITLE
Add contact details to the contact section

### DIFF
--- a/src/components/sections/Contact/Contact.module.scss
+++ b/src/components/sections/Contact/Contact.module.scss
@@ -1,5 +1,9 @@
 .container {
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
 }
 
 .title {
@@ -7,4 +11,41 @@
   width: 100%;
   text-align: center;
   font-size: 42px;
+}
+
+.cards {
+  width: min(520px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card {
+  width: 100%;
+  padding: 18px 20px;
+  border-radius: 12px;
+  background-color: var(--titanium-blue);
+  border: 1px solid var(--light-blue);
+  color: var(--light-text);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: transform 150ms ease, color 150ms ease, border-color 150ms ease;
+  box-sizing: border-box;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  border-color: var(--lighter-blue);
+  color: var(--lighter-blue);
+}
+
+.label {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.value {
+  font-size: 16px;
+  color: currentColor;
 }

--- a/src/components/sections/Contact/Contact.tsx
+++ b/src/components/sections/Contact/Contact.tsx
@@ -2,9 +2,41 @@ import React from "react"
 import * as classes from "./Contact.module.scss"
 
 export default () => {
+  const contactMethods = [
+    {
+      label: "GitHub",
+      href: "https://github.com/Vishwa061",
+      value: "https://github.com/Vishwa061",
+    },
+    {
+      label: "LinkedIn",
+      href: "https://www.linkedin.com/in/vishwa-perera",
+      value: "https://www.linkedin.com/in/vishwa-perera",
+    },
+    {
+      label: "Email",
+      href: "mailto:vishwainnovates@gmail.com",
+      value: "vishwainnovates@gmail.com",
+    },
+  ]
+
   return (
     <section id="contact" className={classes.container}>
       <h2 className={classes.title}>Contact Me</h2>
+      <div className={classes.cards}>
+        {contactMethods.map((contact) => (
+          <a
+            href={contact.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={classes.card}
+            key={contact.label}
+          >
+            <span className={classes.label}>{contact.label}</span>
+            <span className={classes.value}>{contact.value}</span>
+          </a>
+        ))}
+      </div>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- add GitHub, LinkedIn, and email details to the Contact section
- style contact cards for quick access to each contact method

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694363f9f600832ea476cb58a99c44e9)