### PR TITLE
Allow experience tags to wrap

### DIFF
--- a/src/components/ExpCard/ExpCard.module.scss
+++ b/src/components/ExpCard/ExpCard.module.scss
@@ -54,6 +54,7 @@
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
+  flex-wrap: wrap;
   gap: 16px;
 }
 


### PR DESCRIPTION
## Summary
- allow experience card tags to wrap to additional rows on narrow layouts

## Testing
- npm run typecheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943684a66f8832ea07c0e877125b253)