### PR TITLE
Add Pocket Flow to solutions section

### DIFF
--- a/src/components/sections/Solutions/Solutions.module.scss
+++ b/src/components/sections/Solutions/Solutions.module.scss
@@ -1,5 +1,9 @@
 .container {
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
 }
 
 .title {
@@ -7,4 +11,132 @@
   width: 100%;
   text-align: center;
   font-size: 42px;
+}
+
+.cards {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.card {
+  width: 100%;
+  display: flex;
+  gap: 24px;
+  padding: 24px;
+  box-sizing: border-box;
+  background-color: var(--titanium-blue);
+  border: 1px solid var(--light-blue);
+  border-radius: 16px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+}
+
+.preview {
+  width: min(320px, 100%);
+  min-width: 220px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: linear-gradient(180deg, #0b1f33 0%, #0c2236 100%);
+  border-radius: 12px;
+  padding: 16px;
+  box-sizing: border-box;
+}
+
+.image {
+  width: 100%;
+  max-width: 260px;
+  height: auto;
+  object-fit: contain;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  color: var(--light-text);
+}
+
+.heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.name {
+  margin: 0;
+  font-size: 28px;
+  color: var(--light-text);
+}
+
+.subtitle {
+  margin: 4px 0 0 0;
+  color: var(--dark-text);
+  font-size: 16px;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.tag {
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--light-blue);
+  color: var(--light-blue);
+  font-size: 13px;
+  background-color: rgba(56, 189, 248, 0.08);
+}
+
+.description {
+  margin: 0;
+  line-height: 1.7;
+}
+
+.feature-block {
+  background-color: rgba(12, 34, 54, 0.7);
+  border-radius: 12px;
+  border: 1px solid rgba(56, 189, 248, 0.4);
+  padding: 12px 16px;
+  box-sizing: border-box;
+}
+
+.feature-title {
+  margin: 0;
+  font-size: 16px;
+  color: var(--lighter-blue);
+}
+
+.feature-list {
+  margin: 8px 0 0 20px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  line-height: 1.6;
+}
+
+@media screen and (max-width: 900px) {
+  .card {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .preview {
+    width: 100%;
+  }
+
+  .heading {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .tags {
+    width: 100%;
+  }
 }

--- a/src/components/sections/Solutions/Solutions.tsx
+++ b/src/components/sections/Solutions/Solutions.tsx
@@ -1,10 +1,69 @@
 import React from "react"
+import pocketFlowLogo from "@/images/pocket-flow.svg"
 import * as classes from "./Solutions.module.scss"
+
+const solutions = [
+  {
+    name: "Pocket Flow",
+    subtitle: "Android budgeting app built with Jetpack Compose",
+    description:
+      "Pocket Flow keeps budgeting fully offline by persisting all user data as JSON in internal storage—no databases or network required.",
+    features: [
+      "Capture expenses with names, prices, categories, and dates",
+      "Flexible recurrences: daily, weekly (with weekday selection), monthly, and yearly—similar to calendar events",
+      "Overview screen that expands recurrences to summarize spend by week, month, year, and next year",
+      "Category management with default icons, add/edit/remove options, and safeguards when expenses exist",
+      "Category pie chart that visualizes spend distribution with percentages and icons",
+      "List view dedicated to recurring expenses for quick reviews",
+    ],
+    tags: ["Android", "Jetpack Compose", "Kotlin", "Offline JSON storage"],
+    image: pocketFlowLogo,
+    imageAlt: "Pocket Flow app logo featuring a pocket holding a dollar bill",
+  },
+]
 
 export default () => {
   return (
     <section id="solutions" className={classes.container}>
       <h2 className={classes.title}>Solutions</h2>
+      <div className={classes.cards}>
+        {solutions.map((solution) => (
+          <article className={classes.card} key={solution.name}>
+            <div className={classes.preview}>
+              <img
+                src={solution.image}
+                alt={solution.imageAlt}
+                className={classes.image}
+                loading="lazy"
+              />
+            </div>
+            <div className={classes.content}>
+              <div className={classes.heading}>
+                <div>
+                  <h3 className={classes.name}>{solution.name}</h3>
+                  <p className={classes.subtitle}>{solution.subtitle}</p>
+                </div>
+                <div className={classes.tags}>
+                  {solution.tags.map((tag) => (
+                    <span className={classes.tag} key={tag}>
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </div>
+              <p className={classes.description}>{solution.description}</p>
+              <div className={classes.featureBlock}>
+                <h4 className={classes.featureTitle}>Highlights</h4>
+                <ul className={classes.featureList}>
+                  {solution.features.map((feature) => (
+                    <li key={feature}>{feature}</li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </article>
+        ))}
+      </div>
     </section>
   )
 }

--- a/src/images/pocket-flow.svg
+++ b/src/images/pocket-flow.svg
@@ -1,0 +1,34 @@
+<svg width="768" height="768" viewBox="0 0 768 768" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="768" height="768" rx="120" fill="#0D8CF2" />
+  <path
+    d="M182 244C182 231.85 191.85 222 204 222H564C576.15 222 586 231.85 586 244V432C586 545.026 494.026 637 381 637H387C273.974 637 182 545.026 182 432V244Z"
+    fill="#1BB572"
+  />
+  <path
+    d="M200 262C200 250.954 208.954 242 220 242H548C559.046 242 568 250.954 568 262V416C568 520.68 482.68 606 378 606H390C285.32 606 200 520.68 200 416V262Z"
+    fill="#23C77C"
+  />
+  <path
+    d="M200 262C200 250.954 208.954 242 220 242H548C559.046 242 568 250.954 568 262V416C568 520.68 482.68 606 378 606H390C285.32 606 200 520.68 200 416V262Z"
+    stroke="#0F8C3F"
+    stroke-width="12"
+    stroke-dasharray="18 14"
+    stroke-linecap="round"
+  />
+  <rect x="288" y="166" width="192" height="220" rx="20" fill="#F6F8FB" />
+  <rect x="312" y="194" width="144" height="12" rx="6" fill="#E1E6F0" />
+  <text x="384" y="330" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="140" font-weight="700" fill="#1AA35D">
+    $
+  </text>
+  <path
+    d="M210 270H558V416C558 512.202 480.202 590 384 590C287.798 590 210 512.202 210 416V270Z"
+    fill="url(#pocketHighlight)"
+    opacity="0.3"
+  />
+  <defs>
+    <linearGradient id="pocketHighlight" x1="384" y1="270" x2="384" y2="590" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFFFFF" stop-opacity="0.28" />
+      <stop offset="1" stop-color="#1BB572" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+</svg>


### PR DESCRIPTION
## Summary
- add a Pocket Flow entry to the Solutions section with description, highlights, and tech tags
- style the Solutions section with a card layout and responsive presentation
- add a Pocket Flow illustration asset for the new solution card

## Testing
- npx tsc --noEmit
- yarn typecheck *(fails in this environment: Yarn 4 could not resolve packages from the existing lockfile)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69436b27bfc8832e8b5a099ddd0aa8f6)