### PR TITLE
Add motto and footer content

### DIFF
--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -1,0 +1,13 @@
+.footer {
+  background-color: var(--darker-navy-blue);
+  border-top: 1px solid var(--section-alt-blue);
+  color: var(--dark-text);
+  text-align: center;
+  padding: 20px 40px;
+  letter-spacing: 0.5px;
+}
+
+.text {
+  margin: 0;
+  font-size: 14px;
+}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,5 +1,14 @@
 import React from "react"
+import * as classes from "./Footer.module.scss"
 
 export default () => {
-  return <footer></footer>
+  const currentYear = new Date().getFullYear()
+
+  return (
+    <footer className={classes.footer}>
+      <p className={classes.text}>
+        © {currentYear} Vishwa Perera. All rights reserved.
+      </p>
+    </footer>
+  )
 }

--- a/src/components/sections/About/About.module.scss
+++ b/src/components/sections/About/About.module.scss
@@ -1,15 +1,18 @@
 .container {
   padding: 80px 100px 150px 120px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 10px;
 }
 
 .hi {
   color: var(--light-blue);
-  display: block;
   letter-spacing: 1px;
 }
 
 .name {
-  display: block;
   color: var(--light-text);
   font-size: var(--scaling-text);
   font-weight: bold;
@@ -17,14 +20,19 @@
 }
 
 .job {
-  display: block;
   color: var(--dark-text);
   font-size: var(--scaling-text);
   font-weight: bold;
 }
 
+.motto {
+  color: var(--lighter-blue);
+  font-size: 18px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
 .desc {
-  display: block;
   color: var(--dark-text);
   max-width: 600px;
   font-size: 16px;

--- a/src/components/sections/About/About.tsx
+++ b/src/components/sections/About/About.tsx
@@ -7,6 +7,7 @@ export default () => {
       <span className={classes.hi}>Hi, my name is</span>
       <span className={classes.name}>Vishwa Perera.</span>
       <span className={classes.job}>I'm a Software Engineer.</span>
+      <span className={classes.motto}>Simplicity Is Innovation</span>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- add centered motto text to the About section
- introduce a styled footer with dynamic copyright text

## Testing
- npx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69436f3e4184832ea46c0bbe68806842)