### PR TITLE
Enhance motto presentation

### DIFF
--- a/src/components/sections/About/About.module.scss
+++ b/src/components/sections/About/About.module.scss
@@ -26,10 +26,11 @@
 }
 
 .motto {
-  color: var(--lighter-blue);
-  font-size: 18px;
+  color: var(--light-blue);
+  font-size: var(--scaling-text);
+  font-style: italic;
   letter-spacing: 1px;
-  text-transform: uppercase;
+  margin-top: 30px;
 }
 
 .desc {

--- a/src/components/sections/About/About.tsx
+++ b/src/components/sections/About/About.tsx
@@ -7,7 +7,7 @@ export default () => {
       <span className={classes.hi}>Hi, my name is</span>
       <span className={classes.name}>Vishwa Perera</span>
       <span className={classes.job}>I'm a Software Engineer</span>
-      <span className={classes.motto}>Simplicity Is Innovation</span>
+      <span className={classes.motto}>“Simplicity Is Innovation”</span>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- increase the about section motto size to match headline text and wrap it in quoted italics
- adjust motto spacing and color for improved positioning and emphasis

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694371c3a184832e940c3ae532c4cb70)