### PR TITLE
Ensure solution previews stretch vertically

### DIFF
--- a/src/components/sections/Solutions/Solutions.module.scss
+++ b/src/components/sections/Solutions/Solutions.module.scss
@@ -24,6 +24,7 @@
   width: 100%;
   display: flex;
   gap: 24px;
+  align-items: stretch;
   padding: 24px;
   box-sizing: border-box;
   background-color: var(--titanium-blue);
@@ -38,6 +39,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  align-self: stretch;
   // background: linear-gradient(180deg, #0b1f33 0%, #0c2236 100%);
   border-radius: 12px;
   padding: 16px;
@@ -48,7 +50,7 @@
 
 .image {
   width: 100%;
-  height: auto;
+  height: 100%;
   object-fit: contain;
   border-radius: 8px;
   display: block;


### PR DESCRIPTION
## Summary
- stretch solution card layout so the preview column matches the full card height
- allow preview images to fill the available height while maintaining aspect ratio

## Testing
- npm run typecheck
- npm run develop -- --host 0.0.0.0 --port 8000 *(fails: gatsby-plugin-robots-txt missing due to registry access error while installing dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694376aa2a00832ead4e833677318a3e)