### PR TITLE
Align experience section styling with solutions

### DIFF
--- a/src/components/ExpCard/ExpCard.module.scss
+++ b/src/components/ExpCard/ExpCard.module.scss
@@ -1,91 +1,131 @@
-.container {
+.card {
+  width: 100%;
+  display: flex;
+  gap: 24px;
+  align-items: stretch;
+  padding: 24px;
+  box-sizing: border-box;
+  background-color: var(--titanium-blue);
+  border: 1px solid var(--light-blue);
+  border-radius: 16px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+}
+
+.preview {
+  width: min(260px, 100%);
+  min-width: 180px;
   display: flex;
   justify-content: center;
-  padding-top: 30px;
-  gap: 50px;
+  align-items: center;
+  align-self: stretch;
+  border-radius: 12px;
+  padding: 16px;
+  box-sizing: border-box;
+  overflow: hidden;
+  background: var(--titanium-blue);
 }
 
-.role-info {
-  color: var(--light-blue);
-  padding-left: 10px;
-  font-size: 16px;
+.logo {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border-radius: 8px;
+  display: block;
 }
 
-.role-interval {
-  color: var(--light-blue);
-  font-size: 12px;
-  font-weight: bold;
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  color: var(--light-text);
+}
+
+.heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 .company {
+  margin: 0;
+  font-size: 28px;
   color: var(--light-text);
-  font-size: 32px;
-  padding: 20px 0px 0px 10px;
-  margin: 0px;
+}
+
+.roleInfo {
+  color: var(--light-blue);
+  font-size: 16px;
+  margin: 4px 0 0 0;
+}
+
+.roleInterval {
+  color: var(--light-blue);
+  font-size: 14px;
+  font-weight: 600;
 }
 
 .location {
   color: var(--dark-text);
-  padding-left: 10px;
+  margin: 4px 0 0 0;
   font-size: 14px;
 }
 
-.desc-container {
-  margin-top: 10px;
-}
-
-.desc-list {
-  border-radius: 10px;
-  background-color: var(--titanium-blue);
-  padding: 20px 30px;
-  color: var(--light-text);
-  font-size: 16px;
-  letter-spacing: 0.5px;
-  margin: 0px;
+.tags {
   display: flex;
-  flex-direction: column;
-  gap: 10px;
-  list-style-position: outside;
-  list-style-type: disc;
-}
-
-.tag-container {
-  margin-top: 10px;
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
   flex-wrap: wrap;
-  gap: 16px;
+  gap: 10px;
 }
 
 .tag {
-  padding: 10px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--light-blue);
   color: var(--light-blue);
-  font-size: 14px;
-  letter-spacing: 0.5px;
-  background-color: var(--titanium-blue);
-  border-radius: 10px;
+  font-size: 13px;
+  background-color: rgba(56, 189, 248, 0.08);
 }
 
-.tag:hover {
+.featureBlock {
+  background-color: rgba(12, 34, 54, 0.7);
+  border-radius: 12px;
+  border: 1px solid rgba(56, 189, 248, 0.4);
+  padding: 12px 16px;
+  box-sizing: border-box;
+}
+
+.featureTitle {
+  margin: 0;
+  font-size: 16px;
   color: var(--lighter-blue);
 }
 
-.details {
-  width: 50%;
-  height: max-content;
-}
-
-.logo-container {
-  width: 300px;
-  background-color: whitesmoke;
+.featureList {
+  margin: 8px 0 0 20px;
+  padding: 0;
   display: flex;
-  justify-content: center;
-  align-items: center;
-  border-radius: 10px;
+  flex-direction: column;
+  gap: 8px;
+  line-height: 1.6;
 }
 
-.logo {
-  width: 80%;
-  height: auto;
+@media screen and (max-width: 900px) {
+  .card {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .preview {
+    width: 100%;
+  }
+
+  .heading {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .tags {
+    width: 100%;
+  }
 }

--- a/src/components/ExpCard/ExpCard.tsx
+++ b/src/components/ExpCard/ExpCard.tsx
@@ -28,23 +28,33 @@ export default ({
   const parsedDesc = desc.map((descItem) => <li key={descItem}>{descItem}</li>)
 
   return (
-    <div className={classes.container}>
-      <div className={classes.details}>
-        <div className={classes.roleInfo}>
-          {roleInfo}
-          {" · "}
-          <span className={classes.roleInterval}>{roleInterval}</span>
-        </div>
-        <h3 className={classes.company}>{company}</h3>
-        <span className={classes.location}>{location}</span>
-        <div className={classes.descContainer}>
-          <ul className={classes.descList}>{parsedDesc}</ul>
-        </div>
-        <div className={classes.tagContainer}>{parsedTags}</div>
+    <article className={classes.card}>
+      <div className={classes.preview}>
+        <img
+          className={classes.logo}
+          src={logo}
+          alt={`${company} logo`}
+          loading="lazy"
+        />
       </div>
-      <div className={classes.logoContainer}>
-        <img className={classes.logo} src={logo} alt="Company Logo" />
+      <div className={classes.content}>
+        <div className={classes.heading}>
+          <div>
+            <h3 className={classes.company}>{company}</h3>
+            <p className={classes.roleInfo}>
+              {roleInfo}
+              {" · "}
+              <span className={classes.roleInterval}>{roleInterval}</span>
+            </p>
+            <p className={classes.location}>{location}</p>
+          </div>
+          <div className={classes.tags}>{parsedTags}</div>
+        </div>
+        <div className={classes.featureBlock}>
+          <h4 className={classes.featureTitle}>Highlights</h4>
+          <ul className={classes.featureList}>{parsedDesc}</ul>
+        </div>
       </div>
-    </div>
+    </article>
   )
 }

--- a/src/components/sections/Experience/Experience.module.scss
+++ b/src/components/sections/Experience/Experience.module.scss
@@ -1,11 +1,9 @@
 .container {
   width: 100%;
-}
-
-.expsContainer {
   display: flex;
   flex-direction: column;
-  gap: 50px;
+  align-items: center;
+  gap: 32px;
 }
 
 .title {
@@ -13,4 +11,11 @@
   width: 100%;
   text-align: center;
   font-size: 42px;
+}
+
+.expsContainer {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }


### PR DESCRIPTION
## Summary
- restyle experience cards to mirror the solutions card layout, including preview, heading, and highlight block structure
- align experience section spacing with the solutions section container styling
- update tag and typography styling on experience cards to match solutions tags and text hierarchy

## Testing
- yarn typecheck *(fails: package missing from lockfile; install required in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946f0903680832e9ded10d7308516b3)