### PR TITLE
Ensure logo previews use white backgrounds

### DIFF
--- a/src/components/ExpCard/ExpCard.module.scss
+++ b/src/components/ExpCard/ExpCard.module.scss
@@ -22,7 +22,7 @@
   padding: 16px;
   box-sizing: border-box;
   overflow: hidden;
-  background: var(--titanium-blue);
+  background: #fff;
 }
 
 .logo {
@@ -31,6 +31,7 @@
   object-fit: contain;
   border-radius: 8px;
   display: block;
+  background: #fff;
 }
 
 .content {


### PR DESCRIPTION
## Summary
- keep experience card logos on white backgrounds so transparent assets remain visible
- revert solutions logo background colors to the original palette

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69470a1b3144832e9564a3c031ab7360)