### PR TITLE
Update navbar active section on scroll

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,41 +3,72 @@ import * as classes from "./Header.module.scss"
 import { Logo } from "@/components"
 import { useLocation } from "@reach/router"
 
+const NAV_SECTIONS = [
+  { id: "about", text: "About" },
+  { id: "experience", text: "Experience" },
+  { id: "solutions", text: "Solutions" },
+  { id: "contact", text: "Contact" },
+]
+
 export default () => {
   const location = useLocation()
-  const [sections, setSections] = useState([
-    { link: "/#about", text: "About", isActive: true },
-    { link: "/#experience", text: "Experience", isActive: false },
-    { link: "/#solutions", text: "Solutions", isActive: false },
-    { link: "/#contact", text: "Contact", isActive: false },
-  ])
+  const [activeSection, setActiveSection] = useState(NAV_SECTIONS[0].id)
 
   useEffect(() => {
-    setSections((prevSections) => {
-      let newSections = [...prevSections]
+    if (!location.hash) {
+      window.scrollTo(0, 0)
+      setActiveSection(NAV_SECTIONS[0].id)
+      return
+    }
 
-      newSections.forEach((s) => {
-        s.isActive = s.link === `/${location.hash}`
-      })
-
-      if (newSections.every((x) => !x.isActive)) {
-        newSections[0].isActive = true
-      }
-
-      if (!location.hash) {
-        window.scrollTo(0, 0)
-      }
-
-      return newSections
-    })
+    const sectionId = location.hash.replace("#", "")
+    if (NAV_SECTIONS.some((section) => section.id === sectionId)) {
+      setActiveSection(sectionId)
+    }
   }, [location])
 
-  const listItems = sections.map((x) => {
-    const activeStyle = x.isActive ? classes.active : ""
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visibleEntries = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
+
+        if (visibleEntries.length === 0) {
+          return
+        }
+
+        const currentId = visibleEntries[0].target.id
+        setActiveSection((prev) => (prev === currentId ? prev : currentId))
+      },
+      {
+        rootMargin: "-30% 0px -50% 0px",
+        threshold: [0.25, 0.5, 0.75],
+      }
+    )
+
+    const elements = NAV_SECTIONS.map(({ id }) =>
+      document.getElementById(id)
+    ).filter((section): section is HTMLElement => Boolean(section))
+
+    elements.forEach((section) => observer.observe(section))
+
+    return () => observer.disconnect()
+  }, [])
+
+  const listItems = NAV_SECTIONS.map((section) => {
+    const activeStyle = section.id === activeSection ? classes.active : ""
     return (
-      <li className={classes.navLink} key={x.link}>
-        <a className={`${classes.navAnchor} ${activeStyle}`} href={x.link}>
-          {x.text}
+      <li className={classes.navLink} key={section.id}>
+        <a
+          className={`${classes.navAnchor} ${activeStyle}`}
+          href={`/#${section.id}`}
+        >
+          {section.text}
         </a>
       </li>
     )


### PR DESCRIPTION
## Summary
- update navbar logic to track visible sections with an IntersectionObserver
- sync active nav item with hash-based navigation and scrolling for smoother highlighting

## Testing
- yarn typecheck


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69470d46f7d0832e8df405da7705e777)