### PR TITLE
Fix navbar active section on scroll

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -32,32 +32,26 @@ export default () => {
       return undefined
     }
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const visibleEntries = entries
-          .filter((entry) => entry.isIntersecting)
-          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
-
-        if (visibleEntries.length === 0) {
-          return
-        }
-
-        const currentId = visibleEntries[0].target.id
-        setActiveSection((prev) => (prev === currentId ? prev : currentId))
-      },
-      {
-        rootMargin: "-30% 0px -50% 0px",
-        threshold: [0.25, 0.5, 0.75],
-      }
-    )
-
     const elements = NAV_SECTIONS.map(({ id }) =>
       document.getElementById(id)
     ).filter((section): section is HTMLElement => Boolean(section))
 
-    elements.forEach((section) => observer.observe(section))
+    const handleScroll = () => {
+      const focusPoint = window.scrollY + window.innerHeight / 3
+      const currentSection = elements
+        .filter((section) => section.offsetTop <= focusPoint)
+        .sort((a, b) => b.offsetTop - a.offsetTop)[0]
 
-    return () => observer.disconnect()
+      const nextActiveId =
+        currentSection?.id ?? elements[0]?.id ?? NAV_SECTIONS[0].id
+
+      setActiveSection((prev) => (prev === nextActiveId ? prev : nextActiveId))
+    }
+
+    handleScroll()
+    window.addEventListener("scroll", handleScroll, { passive: true })
+
+    return () => window.removeEventListener("scroll", handleScroll)
   }, [])
 
   const listItems = NAV_SECTIONS.map((section) => {


### PR DESCRIPTION
## Summary
- replace the navbar IntersectionObserver logic with scroll position tracking so the active link updates reliably
- initialize active section based on scroll position to keep highlight in sync on load

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69470f305150832e8ceb137155f5088e)