### PR TITLE
Improve responsive layout and mobile navigation

### DIFF
--- a/src/components/ExpCard/ExpCard.module.scss
+++ b/src/components/ExpCard/ExpCard.module.scss
@@ -130,3 +130,31 @@
     width: 100%;
   }
 }
+
+@media screen and (max-width: 600px) {
+  .card {
+    padding: 16px;
+    gap: 16px;
+  }
+
+  .preview {
+    min-width: 0;
+    padding: 12px;
+  }
+
+  .company {
+    font-size: 22px;
+  }
+
+  .roleInfo {
+    font-size: 15px;
+  }
+
+  .featureBlock {
+    padding: 10px 12px;
+  }
+
+  .featureList {
+    gap: 6px;
+  }
+}

--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -11,3 +11,9 @@
   margin: 0;
   font-size: 14px;
 }
+
+@media screen and (max-width: 600px) {
+  .footer {
+    padding: 16px 24px;
+  }
+}

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -1,25 +1,27 @@
 .header {
   height: 100px;
   width: 100%;
-  padding: 25px 50px 25px 50px;
+  padding: 20px 40px;
   box-sizing: border-box;
   align-items: center;
   position: fixed;
   background-color: var(--darker-navy-blue);
   z-index: 1000;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
 }
 
 .nav {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  position: relative;
+  gap: 16px;
 }
 
 .nav-right-container {
-  text-decoration-line: none;
-  text-decoration-skip-ink: auto;
-  text-decoration-style: solid;
-  text-decoration-thickness: auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .nav-links-container {
@@ -29,22 +31,122 @@
   justify-content: space-between;
   display: flex;
   align-items: center;
+  gap: 4px;
 }
 
 .nav-link {
-  margin: 0px 5px 0px 5px;
-  border-radius: 5px;
+  margin: 0px 2px;
+  border-radius: 8px;
 }
 
 .nav-anchor {
   color: var(--light-text);
+  width: auto;
+  height: auto;
   display: block;
-  padding: 15px;
+  padding: 14px 16px;
   font-size: 13px;
   font-weight: bold;
   letter-spacing: 1px;
+  transition: color 150ms ease, background-color 150ms ease;
+}
+
+.nav-anchor:hover {
+  color: var(--lighter-blue);
+  background-color: rgba(56, 189, 248, 0.08);
 }
 
 .active {
   color: var(--light-blue) !important;
+}
+
+.menu-button {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  border: 1px solid var(--section-alt-blue);
+  background: rgba(12, 34, 54, 0.8);
+  cursor: pointer;
+  transition: border-color 150ms ease, background-color 150ms ease;
+}
+
+.menu-button:focus-visible {
+  outline: 2px solid var(--light-blue);
+  outline-offset: 3px;
+}
+
+.menu-button:hover {
+  border-color: var(--light-blue);
+  background-color: rgba(9, 26, 42, 0.8);
+}
+
+.menu-icon {
+  position: relative;
+  width: 18px;
+  height: 2px;
+  background: var(--light-text);
+  border-radius: 999px;
+}
+
+.menu-icon::before,
+.menu-icon::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--light-text);
+  border-radius: 999px;
+}
+
+.menu-icon::before {
+  top: -6px;
+}
+
+.menu-icon::after {
+  top: 6px;
+}
+
+@media screen and (max-width: 960px) {
+  .header {
+    padding: 16px 24px;
+    height: 90px;
+  }
+
+  .nav-links-container {
+    background: rgba(9, 26, 42, 0.98);
+    border: 1px solid var(--section-alt-blue);
+    border-radius: 12px;
+    position: absolute;
+    top: calc(100% - 6px);
+    right: 0;
+    width: 280px;
+    padding: 12px 10px;
+    box-shadow: 0 14px 40px rgba(0, 0, 0, 0.35);
+    flex-direction: column;
+    align-items: stretch;
+    gap: 6px;
+    display: none;
+  }
+
+  .nav-links-open {
+    display: flex;
+  }
+
+  .nav-link {
+    margin: 0;
+  }
+
+  .nav-anchor {
+    width: 100%;
+    padding: 12px 14px;
+    border-radius: 8px;
+  }
+
+  .menu-button {
+    display: inline-flex;
+  }
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -13,6 +13,7 @@ const NAV_SECTIONS = [
 export default () => {
   const location = useLocation()
   const [activeSection, setActiveSection] = useState(NAV_SECTIONS[0].id)
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
 
   useEffect(() => {
     if (!location.hash) {
@@ -25,6 +26,8 @@ export default () => {
     if (NAV_SECTIONS.some((section) => section.id === sectionId)) {
       setActiveSection(sectionId)
     }
+
+    setIsMenuOpen(false)
   }, [location])
 
   useEffect(() => {
@@ -56,11 +59,14 @@ export default () => {
 
   const listItems = NAV_SECTIONS.map((section) => {
     const activeStyle = section.id === activeSection ? classes.active : ""
+    const closeMenu = () => setIsMenuOpen(false)
+
     return (
       <li className={classes.navLink} key={section.id}>
         <a
           className={`${classes.navAnchor} ${activeStyle}`}
           href={`/#${section.id}`}
+          onClick={closeMenu}
         >
           {section.text}
         </a>
@@ -73,7 +79,22 @@ export default () => {
       <nav className={classes.nav}>
         <Logo />
         <div className={classes.navRightContainer}>
-          <ol className={classes.navLinksContainer}>{listItems}</ol>
+          <button
+            type="button"
+            aria-expanded={isMenuOpen}
+            aria-label="Toggle navigation menu"
+            className={classes.menuButton}
+            onClick={() => setIsMenuOpen((open) => !open)}
+          >
+            <span className={classes.menuIcon} aria-hidden="true" />
+          </button>
+          <ol
+            className={`${classes.navLinksContainer} ${
+              isMenuOpen ? classes.navLinksOpen : ""
+            }`}
+          >
+            {listItems}
+          </ol>
         </div>
       </nav>
     </header>

--- a/src/components/Layout/Layout.module.scss
+++ b/src/components/Layout/Layout.module.scss
@@ -1,5 +1,5 @@
 .main {
-  padding: 100px 0px 0px 0px;
+  padding: clamp(80px, 12vw, 100px) 0px 0px 0px;
 }
 
 // https://www.w3schools.com/accessibility/accessibility_skip_links.php

--- a/src/components/sections/About/About.module.scss
+++ b/src/components/sections/About/About.module.scss
@@ -50,3 +50,38 @@
   text-decoration-thickness: 1px;
   text-underline-offset: 3px;
 }
+
+@media screen and (max-width: 900px) {
+  .container {
+    padding: 70px 48px 120px;
+    gap: 14px;
+  }
+
+  .name,
+  .job,
+  .motto {
+    font-size: clamp(32px, 8vw, 64px);
+  }
+
+  .motto {
+    margin-top: 64px;
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .container {
+    padding: 60px 24px 90px;
+  }
+
+  .hi {
+    font-size: 14px;
+  }
+
+  .desc {
+    font-size: 15px;
+  }
+
+  .motto {
+    margin-top: 40px;
+  }
+}

--- a/src/components/sections/Contact/Contact.module.scss
+++ b/src/components/sections/Contact/Contact.module.scss
@@ -49,3 +49,32 @@
   font-size: 16px;
   color: currentColor;
 }
+
+@media screen and (max-width: 900px) {
+  .title {
+    font-size: 32px;
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .container {
+    gap: 24px;
+  }
+
+  .title {
+    font-size: 28px;
+  }
+
+  .card {
+    padding: 16px 18px;
+    gap: 12px;
+  }
+
+  .label {
+    font-size: 17px;
+  }
+
+  .value {
+    font-size: 15px;
+  }
+}

--- a/src/components/sections/Experience/Experience.module.scss
+++ b/src/components/sections/Experience/Experience.module.scss
@@ -19,3 +19,19 @@
   flex-direction: column;
   gap: 20px;
 }
+
+@media screen and (max-width: 900px) {
+  .title {
+    font-size: 32px;
+  }
+
+  .container {
+    gap: 26px;
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .title {
+    font-size: 28px;
+  }
+}

--- a/src/components/sections/Solutions/Solutions.module.scss
+++ b/src/components/sections/Solutions/Solutions.module.scss
@@ -146,3 +146,32 @@
     width: 100%;
   }
 }
+
+@media screen and (max-width: 900px) {
+  .title {
+    font-size: 32px;
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .card {
+    padding: 16px;
+    gap: 16px;
+  }
+
+  .title {
+    font-size: 28px;
+  }
+
+  .subtitle {
+    font-size: 15px;
+  }
+
+  .feature-block {
+    padding: 10px 12px;
+  }
+
+  .feature-list {
+    gap: 6px;
+  }
+}

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -9,7 +9,7 @@
   --light-text: #dededeee;
   --dark-text: #939cb9;
   --font-inter: "Inter";
-  --scaling-text: clamp(40px, 8vw, 80px);
+  --scaling-text: clamp(36px, 7vw, 80px);
 }
 
 html {
@@ -31,7 +31,7 @@ main {
 main section {
   box-sizing: border-box;
   min-height: calc(100vh - 100px);
-  padding: 80px 100px;
+  padding: clamp(56px, 8vw, 80px) clamp(20px, 8vw, 100px);
   background-color: var(--dark-navy-blue);
 }
 


### PR DESCRIPTION
## Summary
- add a mobile navigation toggle with updated header spacing and styling
- adjust global section padding and hero/section typography for smaller breakpoints
- refine card spacing and typography in experience, solutions, and contact sections for mobile readability

## Testing
- npm run typecheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694711124668832e91959a78cda5cc0f)